### PR TITLE
Provide empty font iterator when `fonts` feature is disabled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,9 +57,12 @@ pub mod icc {
 
 /// Bundled fonts.
 ///
-/// This is only available if the `fonts` feature is enabled.
-#[cfg(feature = "fonts")]
+/// This returns an empty iterator if the `fonts` feature is disabled.
 pub fn fonts() -> impl Iterator<Item = &'static [u8]> {
+    #[cfg(not(feature = "fonts"))]
+    return [].into_iter();
+
+    #[cfg(feature = "fonts")]
     [
         asset!("fonts/LinLibertine_R.ttf"),
         asset!("fonts/LinLibertine_RB.ttf"),
@@ -77,9 +80,4 @@ pub fn fonts() -> impl Iterator<Item = &'static [u8]> {
         asset!("fonts/DejaVuSansMono.ttf"),
     ]
     .into_iter()
-}
-
-#[cfg(not(feature = "fonts"))]
-pub fn fonts() -> impl Iterator<Item = &'static [u8]> {
-    [].into_iter()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,3 +78,8 @@ pub fn fonts() -> impl Iterator<Item = &'static [u8]> {
     ]
     .into_iter()
 }
+
+#[cfg(not(feature = "fonts"))]
+pub fn fonts() -> impl Iterator<Item = &'static [u8]> {
+    [].into_iter()
+}


### PR DESCRIPTION
I'm doing similar thing manually at https://github.com/Enter-tainer/typst-preview/commit/4a37fb55abaedaec06827e041d9e645add2d5f03#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR151